### PR TITLE
Disable shared library build for now. Getting a build error on Linux

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -78,7 +78,7 @@ class LibmicrohttpdConan(ConanFile):
                 self.output.info("Activated option! %s" % option_name)
                 config_options_string += " --%s" % option_name.replace("_", "-")
 
-        configure_command = "cd %s && %s ./configure --enable-static --enable-shared %s" % (self.ZIP_FOLDER_NAME, self.generic_env_configure_vars(), config_options_string)
+        configure_command = "cd %s && %s ./configure --enable-static --disable-shared %s" % (self.ZIP_FOLDER_NAME, self.generic_env_configure_vars(), config_options_string)
         self.output.warn(configure_command)
         self.run(configure_command)
         self.run("cd %s && make" % self.ZIP_FOLDER_NAME)


### PR DESCRIPTION
when building shared library

Link error partial log:
rohttpd.so.12 -o .libs/libmicrohttpd.so.12.39.0
/usr/bin/ld: /home/rsubramanian/.conan/data/gmp/6.1.1/DEGoodmanWilson/testing/package/87afed00f19423e47c9f5cf7c37bba94ddf0f908/lib/libgmp.a(divrem_1.o): relocation R_X86_64_PC32 against symbol `__gmpn_invert_limb' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: final link failed: Bad value
collect2: error: ld returned 1 exit status
make[3]: *** [libmicrohttpd.la] Error 1
make[3]: Leaving directory`/home/rsubramanian/.conan/data/libmicrohttpd/0.9.51/DEGoodmanWilson/testing/build/d5ba3498673544fee9d425d9394179131f20295d/libmicrohttpd-0.9.51/src/microhttpd'
make[2]: **\* [all-recursive] Error 1
make[2]: Leaving directory `/home/rsubramanian/.conan/data/libmicrohttpd/0.9.51/DEGoodmanWilson/testing/build/d5ba3498673544fee9d425d9394179131f20295d/libmicrohttpd-0.9.51/src'
make[1]: *** [all-recursive] Error 1
make[1]: Leaving directory`/home/rsubramanian/.conan/data/libmicrohttpd/0.9.51/DEGoodmanWilson/testing/build/d5ba3498673544fee9d425d9394179131f20295d/libmicrohttpd-0.9.51'
make: **\* [all] Error 2
